### PR TITLE
Add option to show background under window number for more clarity

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -217,6 +217,10 @@ you need set this value to `/usr/share/stardict/dic/stardict-oxford-gb-formated-
   "Show window border if enable this option."
   :type 'boolean)
 
+(defcustom holo-layer-enable-window-number-background nil
+  "Show background for window number more clarity if enable this option."
+  :type 'boolean)
+
 (defcustom holo-layer-window-number-color "#cc2444"
   "Color for window number."
   :type 'string)

--- a/plugin/window_number.py
+++ b/plugin/window_number.py
@@ -10,8 +10,10 @@ class WindowNumber(QObject):
 
         self.text_color = None
 
-        (text_color, self.font_size) = get_emacs_vars(["holo-layer-window-number-color",
-                                                       "holo-layer-window-number-font-size"])
+        (text_color, self.font_size, self.enable_background) = get_emacs_vars(["holo-layer-window-number-color",
+                                                                               "holo-layer-window-number-font-size",
+                                                                               "holo-layer-enable-window-number-background",
+                                                                               ])
 
         self.text_color = QColor(text_color)
         self.font_family = QFontDatabase.systemFont(
@@ -22,14 +24,19 @@ class WindowNumber(QObject):
         self.font.setPointSize(self.font_size)
 
         self.margin_left = 20
+        self.back_color = QColor(125,125,125,70)
 
     def draw(self, painter, window_info, emacs_frame_info):
         if len(window_info) > 1:
             [emacs_x, emacs_y, emacs_w, emacs_h] = emacs_frame_info
             for index, info in enumerate(sorted(window_info, key=lambda window: (window[1], window[0]))):
                 [x, y, w, h, is_active_window] = info
-
+                
+                if self.enable_background:
+                    painter.setPen(self.back_color)
+                    painter.setBrush(self.back_color)
+                    painter.drawRect(QRectF(emacs_x + x, emacs_y + y, self.font_size + self.margin_left + 10, self.font_size + 10))
+                
                 painter.setFont(self.font)
-
                 painter.setPen(self.text_color)
                 painter.drawText(QRectF(emacs_x + x + self.margin_left, emacs_y + y, w, h), Qt.AlignmentFlag.AlignLeft, str(index + 1))


### PR DESCRIPTION
在window number增加了一个半透明背景，使window number更容易看清楚，和背后的代码有所区分
![2023-09-20_21-48-49](https://github.com/manateelazycat/holo-layer/assets/15925432/ff201ecb-dd14-4c5c-94c0-3e82235b8a86)
