### PR TITLE
Fix problems on frame-info and window-info, Fix sort-tabs

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -417,8 +417,8 @@ Such as, wayland native, macOS etc."
                  ") | .at'"))))
                 (monitor-coordinate (json-parse-string (shell-command-to-string 
                   "hyprctl monitors -j | jq '.[] | select(.focused == true) | [.x,.y]'")))
-								(frame-x (- (aref frame-coordinate 0) (aref monitor-coordinate 0)))
-								(frame-y (- (aref frame-coordinate 1) (aref monitor-coordinate 1))))
+                (frame-x (- (aref frame-coordinate 0) (aref monitor-coordinate 0)))
+                (frame-y (- (aref frame-coordinate 1) (aref monitor-coordinate 1))))
            (list frame-x frame-y)))
         ((holo-layer-emacs-running-in-wayland-native)
          (require 'dbus)
@@ -430,7 +430,7 @@ Such as, wayland native, macOS etc."
                 (frame-y (truncate (/ (cadr coordinate) (frame-scale-factor)))))
            (list frame-x frame-y)))
         (t
-         (list (car (frame-position)) (cdar (frame-position))))))
+         (list (car (frame-position)) (cdr (frame-position))))))
 
 (defun holo-layer-get-window-allocation (&optional window)
   "Get WINDOW allocation."

--- a/plugin/sort_tab.py
+++ b/plugin/sort_tab.py
@@ -114,7 +114,7 @@ class SortTab(QObject):
 
                 # Translate tab line along with scroll position.
                 current_tab_index = sort_tab_info["current_tab_index"]
-                current_tab_x_offset = 0
+                current_tab_x_offset = x
                 for index, tab_name in enumerate(tab_names):
                     # Calculate tab width and icon offset.
                     tab_render_name = self.get_tab_render_name(tab_name)
@@ -146,7 +146,7 @@ class SortTab(QObject):
                     current_tab_x_offset += icon_offset + tab_width + self.tab_padding_x * 2
 
                 # Draw tabs.
-                tab_x_offset = 0
+                tab_x_offset = x
                 for index, tab_name in enumerate(tab_names):
                     # Get tab width and icon offset.
                     tab_render_name = self.get_tab_render_name(tab_name)
@@ -188,7 +188,7 @@ class SortTab(QObject):
                     tab_x_offset += icon_offset + tab_width + self.tab_padding_x * 2
 
                 # Draw tab spliter, we can't draw tab spliter along with tab content, otherwhere tab spliter will override by next tab content.
-                tab_x_offset = 0
+                tab_x_offset = x
                 for index, tab_name in enumerate(tab_names):
                     # Get tab width and icon offset.
                     tab_render_name = self.get_tab_render_name(tab_name)


### PR DESCRIPTION
It is a little complicated.

# Let me first point out the problems

The emacs built-in function `(frame-position)` (that are called inside `(holo-layer-get-emacs-frame-info)`) have problem running on hyprland, gnome-wayland and maybe other wayland-wms. It returns (0,0) on hyprland and something else on gnome-wayland. Therefore there should be a patch.

The good news is that there's already a patch, `(holo-layer--get-frame-coordinate)`. The problem is that this patch was used in `(holo-layer-get-window-info)`. `(holo-layer-get-emacs-frame-info)` didn't receive this patch. 

Therefore, the plugins that only rely on frame-info do not draw correctly. For example, sort-tabs, cursor-animations, and therefore they have an offset to the right place.

But there're plugins that rely on both frame-info and window-info, for example, window-borders. 
It draws at `x = frame_x + window_x`, .aka it's treating window_x as an offset on x relative to frame. 
However `frame_x` from `(holo-layer-get-emacs-frame-info)` doesn't get patched, `window_x` from `(holo-layer-get-window-info)` get's patched (which is wrong if we treat window_x as an offset on x relative to frame). The two wrong thing add together and result in a right thing. So we get window-borders drawing at the right place!

# Two ways to fix this

1. patch `(holo-layer-get-emacs-frame-info)`, remove patch in `(holo-layer-get-window-info)`. This will treat window-info as offsets relative to emacs-frame.

2. patch `(holo-layer-get-emacs-frame-info)`, do not touch  `(holo-layer-get-window-info)`, remove the use of emacs_frame_info in window-borders and possibly other plugins. This will treat window-info as absolute coordinates on the desktop.

Currently I choose the first way. But this fix is possible to break other stuffs on other kinds of desktops.

# Fix on sort tabs
it seems that sort-tabs was not respecting `emacs_frame_x` but respecting `emacs_frame_y`.
