### PR TITLE
Allow to use current cursor color in cursor animation

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -721,7 +721,7 @@ Including title-bar, menu-bar, offset depends on window system, and border."
       (when (and (> y (- (+ window-y window-h) h)) (equal holo-layer-last-window (selected-window)))
         (setq y (- (+ window-y window-h) h)))
       (setq holo-layer-last-window (selected-window))
-      (format "%s:%s:%s:%s" x y w h))))
+      (format "%s:%s:%s:%s:%s" x y w h (face-background 'cursor)))))
 
 (defun holo-layer-get-window-info (frame window current-window)
   (with-current-buffer (window-buffer window)


### PR DESCRIPTION
增加了功能：当 `holo-layer-cursor-color` 的值为 `nil` 的时候，cursor_animation 会使用当前光标的颜色展示动画。这样当 Emasc 里面的光标颜色变化之后（比如不同 evil mode 用不同颜色的光标），cursor_animation 展示出来的颜色更协调。
实现：在 `cursor_info` 的最后增加了当前光标的颜色，从而传递到 python 端。
