### PR TITLE
Support multiple displays on Mac and fix an indent line bug.

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -504,7 +504,9 @@ Including title-bar, menu-bar, offset depends on window system, and border."
     (list (+ (car pos) (car external-border-size) (if (memq system-type '(cygwin windows-nt ms-dos)) 0 (car title-bar-size)))
           (+ (cadr pos) (cdr external-border-size) (cdr title-bar-size))
           width
-          height)))
+          height
+          (cl-position (frame-monitor-geometry) (display-monitor-attributes-list)
+                       :test (lambda (f attr) (equal f (cdr (car attr))))))))
 
 (defun holo-layer-eaf-fullscreen-p ()
   (and (featurep 'eaf)

--- a/holo_layer.py
+++ b/holo_layer.py
@@ -255,6 +255,7 @@ class HoloWindow(QWidget):
         self.setStyleSheet("background-color:transparent;")
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
+        self.screen_index = 0
         self.screen = QGuiApplication.primaryScreen()
         self.screen_geometry = self.screen.availableGeometry()
         self.setGeometry(self.screen_geometry)
@@ -355,9 +356,21 @@ class HoloWindow(QWidget):
         self.emacs_indent_infos = emacs_indent_infos
         self.update()
 
+    def update_screen_geometry_info(self, screen_index):
+        if platform.system() != "Darwin":
+            return
+        if screen_index != self.screen_index:
+            self.screen_index = screen_index
+            self.screen = super().screen().virtualSiblings()[screen_index]
+            self.screen_geometry = self.screen.availableGeometry()
+            self.window_bias_x, self.window_bias_y = self.screen_geometry.x(), self.screen_geometry.y()
+            self.setGeometry(self.screen_geometry)
+            self.move(self.window_bias_x, self.window_bias_y)
+   
     def update_info(self, emacs_frame_info, window_info, cursor_info, menu_info, sort_tab_info, is_insert_command):
         if emacs_frame_info:
-            self.emacs_frame_info = emacs_frame_info.copy()
+            self.emacs_frame_info = emacs_frame_info[:4].copy()
+            self.update_screen_geometry_info(emacs_frame_info[4])
             self.emacs_frame_info[0] -= self.window_bias_x
             self.emacs_frame_info[1] -= self.window_bias_y
 

--- a/plugin/indent_line.py
+++ b/plugin/indent_line.py
@@ -22,7 +22,7 @@ class IndentLine(QObject):
                 # TODO only line indent is not enough to get indent line
                 # need add text objects info from lang parser
                 indents = [int(i) for i in indents.split(',')]
-                cursor_x, cursor_y, cursor_w, cursor_h = [int(i) for i in cursor_info.split(':')]
+                cursor_x, cursor_y, cursor_w, cursor_h = [int(i) for i in cursor_info.split(':')[:4]]
                 window_info = [int(i) for i in window_indent_info.split(':')[:4]]
 
                 x, y, w, h = window_info


### PR DESCRIPTION
macos 使用多个显示器的时候，能够识别到当前的显示器。并修复 indent_line 解析参数时的报错。参数改变是因为下面这个 pr https://github.com/manateelazycat/holo-layer/pull/38 