### PR TITLE
Fix the incorrect display of the scroll bar on macOS.

### DIFF
--- a/holo_layer.py
+++ b/holo_layer.py
@@ -409,6 +409,13 @@ class HoloWindow(QWidget):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+    app.setStyleSheet("""
+        QScrollBar:vertical, QScrollBar:horizontal {
+            width: 0px;
+            height: 0px;
+        }
+    """)
+
     HoloLayer(sys.argv[1:])
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
这个 issue 对应的PR：[macos 窗口调整到最大的时候，consult-buffer可能导致出现滚动条](https://github.com/manateelazycat/holo-layer/issues/43)