### PR TITLE
修复active window border

### DIFF
--- a/plugin/window_border.py
+++ b/plugin/window_border.py
@@ -16,7 +16,10 @@ class WindowBorder(QObject):
                                                       "holo-layer-enable-window-border"])
 
         self.active_window_border_color = QColor(active_window_border_color)
-        self.inactive_window_border_color = QColor(inactive_window_border_color)
+
+        self.inactive_window_border_color = None
+        if inactive_window_border_color:
+            self.inactive_window_border_color = QColor(inactive_window_border_color)
 
     def draw(self, painter, window_info, emacs_frame_info):
         if self.enable_window_border and emacs_frame_info:
@@ -34,7 +37,7 @@ class WindowBorder(QObject):
                 for info in window_info:
                     [x, y, w, h, is_active_window] = info
 
-                    if is_active_window == "nil":
+                    if is_active_window == "nil" and self.inactive_window_border_color:
                         painter.setPen(self.inactive_window_border_color)
                         self.draw_window_border(painter, emacs_frame_info, info)
 
@@ -43,10 +46,19 @@ class WindowBorder(QObject):
                     [x, y, w, h, is_active_window] = info
 
                     if is_active_window == "t":
-                        painter.setPen(self.active_window_border_color)
-                        [emacs_x, emacs_y, emacs_width, emacs_height] = emacs_frame_info
+                        pen = painter.pen()
+                        pen.setWidth(3)
+                        pen.setColor(self.active_window_border_color)
+                        painter.setPen(pen)
 
-                        painter.drawRect(x + emacs_x, y + emacs_y + h - 1, w, 1)
+                        [
+                            emacs_x,
+                            emacs_y,
+                            emacs_width,
+                            emacs_height,
+                        ] = emacs_frame_info
+
+                        painter.drawRect(x + emacs_x, y + emacs_y, w, h)
 
     def draw_window_border(self, painter, emacs_frame_info, info):
         [x, y, w, h, is_active_window] = info

--- a/plugin/window_border.py
+++ b/plugin/window_border.py
@@ -58,7 +58,7 @@ class WindowBorder(QObject):
                             emacs_height,
                         ] = emacs_frame_info
 
-                        painter.drawRect(x + emacs_x, y + emacs_y, w, h - 2)
+                        painter.drawRect(x + emacs_x, y + emacs_y, w, h)
 
     def draw_window_border(self, painter, emacs_frame_info, info):
         [x, y, w, h, is_active_window] = info

--- a/plugin/window_border.py
+++ b/plugin/window_border.py
@@ -47,7 +47,7 @@ class WindowBorder(QObject):
 
                     if is_active_window == "t":
                         pen = painter.pen()
-                        pen.setWidth(3)
+                        pen.setWidth(2)
                         pen.setColor(self.active_window_border_color)
                         painter.setPen(pen)
 
@@ -58,7 +58,7 @@ class WindowBorder(QObject):
                             emacs_height,
                         ] = emacs_frame_info
 
-                        painter.drawRect(x + emacs_x, y + emacs_y, w, h)
+                        painter.drawRect(x + emacs_x, y + emacs_y, w, h - 2)
 
     def draw_window_border(self, painter, emacs_frame_info, info):
         [x, y, w, h, is_active_window] = info

--- a/plugin/window_border.py
+++ b/plugin/window_border.py
@@ -9,17 +9,25 @@ class WindowBorder(QObject):
     def __init__(self) -> None:
         super().__init__()
 
-        (active_window_border_color,
-         inactive_window_border_color,
-         self.enable_window_border) = get_emacs_vars(["holo-layer-active-window-color",
-                                                      "holo-layer-inactive-window-color",
-                                                      "holo-layer-enable-window-border"])
+        (
+            active_window_border_color,
+            inactive_window_border_color,
+            self.enable_window_border,
+        ) = get_emacs_vars(
+            [
+                "holo-layer-active-window-color",
+                "holo-layer-inactive-window-color",
+                "holo-layer-enable-window-border",
+            ]
+        )
 
         self.active_window_border_color = QColor(active_window_border_color)
 
         self.inactive_window_border_color = None
         if inactive_window_border_color:
-            self.inactive_window_border_color = QColor(inactive_window_border_color)
+            self.inactive_window_border_color = QColor(
+                inactive_window_border_color
+            )
 
     def draw(self, painter, window_info, emacs_frame_info):
         if self.enable_window_border and emacs_frame_info:
@@ -30,14 +38,17 @@ class WindowBorder(QObject):
                 [x, y, w, h, _] = window_info[0]
                 [emacs_x, emacs_y, emacs_width, emacs_height] = emacs_frame_info
 
-                painter.setPen(self.active_window_border_color)
-                painter.drawRect(x + emacs_x, y + emacs_y + h - 1, w, 1)
+                # painter.setPen(self.active_window_border_color)
+                # painter.drawRect(x + emacs_x, y + emacs_y + h - 1, w, 1)
             elif len(window_info) > 1:
                 # Draw inactive window border.
                 for info in window_info:
                     [x, y, w, h, is_active_window] = info
 
-                    if is_active_window == "nil" and self.inactive_window_border_color:
+                    if (
+                        is_active_window == "nil"
+                        and self.inactive_window_border_color
+                    ):
                         painter.setPen(self.inactive_window_border_color)
                         self.draw_window_border(painter, emacs_frame_info, info)
 


### PR DESCRIPTION
原先版本中的active window border显示有点问题，只会在下方展示一条横线。修改了drawRect的参数。
另外增加了对inactive_window_border_color的判断，如果`holo-layer-inactive-window-color`是nil，则不展示inactive window boder。