### PR TITLE
Fix "add-to-list" compilation error.

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -309,34 +309,34 @@ Default is disable.")
                               (not (string-match-p "QT_SCREEN_SCALE_FACTOR" var))))
                        process-environment)))
     (when holo-layer-enable-debug
-      (add-to-list 'environments "QT_DEBUG_PLUGINS=1" t))
+      (cl-pushnew "QT_DEBUG_PLUGINS=1" environments :test #'equal))
 
     (unless (eq system-type 'darwin)
-      (add-to-list 'environments
-                   (cond
-                    ((holo-layer-emacs-running-in-wayland-native)
-                     ;; Wayland native need to set QT_AUTO_SCREEN_SCALE_FACTOR=1
-                     ;; otherwise Qt window only have half of screen.
-                     "QT_AUTO_SCREEN_SCALE_FACTOR=1")
-                    (t
-                     ;; XWayland need to set QT_AUTO_SCREEN_SCALE_FACTOR=0
-                     ;; otherwise Qt which explicitly force high DPI enabling get scaled TWICE.
-                     "QT_AUTO_SCREEN_SCALE_FACTOR=0"))
-                   t)
+      (cl-pushnew (cond
+                   ((holo-layer-emacs-running-in-wayland-native)
+                    ;; Wayland native need to set QT_AUTO_SCREEN_SCALE_FACTOR=1
+                    ;; otherwise Qt window only have half of screen.
+                    "QT_AUTO_SCREEN_SCALE_FACTOR=1")
+                   (t
+                    ;; XWayland need to set QT_AUTO_SCREEN_SCALE_FACTOR=0
+                    ;; otherwise Qt which explicitly force high DPI enabling get scaled TWICE.
+                    "QT_AUTO_SCREEN_SCALE_FACTOR=0"))
+                  environments
+                  :test #'equal)
 
-      (add-to-list 'environments "QT_FONT_DPI=96" t)
+      (cl-pushnew "QT_FONT_DPI=96" environments :test #'equal)
 
       ;; Make sure holo layer application scale support 4k screen.
-      (add-to-list 'environments "QT_SCALE_FACTOR=1" t)
+      (cl-pushnew "QT_SCALE_FACTOR=1" environments :test #'equal)
 
       ;; Fix CORS problem.
-      (add-to-list 'environments "QTWEBENGINE_CHROMIUM_FLAGS=--disable-web-security" t)
+      (cl-pushnew "QTWEBENGINE_CHROMIUM_FLAGS=--disable-web-security" environments :test #'equal)
 
       ;; Use XCB for input event transfer.
       ;; Only enable this option on Linux platform.
       (when (and (eq system-type 'gnu/linux)
                  (not (holo-layer-emacs-running-in-wayland-native)))
-        (add-to-list 'environments "QT_QPA_PLATFORM=xcb" t)))
+        (cl-pushnew "QT_QPA_PLATFORM=xcb" environments :test #'equal)))
     environments))
 
 (defun holo-layer-start-process ()


### PR DESCRIPTION
Compilation error:
`error   ‘add-to-list’ can’t use lexical var ‘environments’; use ‘push’ or ‘cl-pushnew’`

In `add-to-list` document string:
This is meant to be used for adding elements to configuration
variables, such as adding a directory to a path variable
like ‘load-path’, but please do not abuse it to construct
arbitrary lists in Elisp code, where using ‘push’ or ‘cl-pushnew’
will get you more efficient code.