### PR TITLE
Fix small bugs concerning multiple screens or workspaces.

### DIFF
--- a/holo-layer.el
+++ b/holo-layer.el
@@ -106,6 +106,7 @@
                (holo-layer-epc-define-method mngr 'get-emacs-var 'holo-layer--get-emacs-var-func)
                (holo-layer-epc-define-method mngr 'get-emacs-vars 'holo-layer--get-emacs-vars-func)
                (holo-layer-epc-define-method mngr 'get-user-emacs-directory 'holo-layer--user-emacs-directory)
+               (holo-layer-epc-define-method mngr 'frame-focus-state 'frame-focus-state)
                (holo-layer-epc-define-method mngr 'get-emacs-id 'holo-layer--get-emacs-id)
                (holo-layer-epc-define-method mngr 'get-emacs-name 'holo-layer--get-emacs-name)
                (holo-layer-epc-define-method mngr 'get-theme-mode 'holo-layer-get-theme-mode)
@@ -515,7 +516,7 @@ Including title-bar, menu-bar, offset depends on window system, and border."
           width
           height
           (cl-position (frame-monitor-geometry) (display-monitor-attributes-list)
-                       :test (lambda (f attr) (equal f (cdr (car attr))))))))
+                       :test (lambda (f attr) (equal f (alist-get 'geometry attr)))))))
 
 (defun holo-layer-eaf-fullscreen-p ()
   (and (featurep 'eaf)
@@ -588,6 +589,7 @@ Including title-bar, menu-bar, offset depends on window system, and border."
 
 (defun holo-layer-monitor-configuration-change (&rest _)
   "Detecting a window configuration change."
+  (setq holo-layer-emacs-frame (window-frame))
   (when (and (holo-layer-epc-live-p holo-layer-epc-process)
              ;; When current frame is same with `emacs-frame'.
              (equal (window-frame) holo-layer-emacs-frame))

--- a/holo_layer.py
+++ b/holo_layer.py
@@ -214,7 +214,7 @@ class HoloLayer:
 
     def check_window_focus(self):
         """Periodically check if Emacs has focus and show/hide holo-layer window accordingly"""
-        if self.get_active_window_id() == self.get_emacs_id():
+        if get_emacs_func_result("frame-focus-state"):
             if not self.holo_window_is_show:
                 self.show_holo_window()
         else:
@@ -380,6 +380,7 @@ class HoloWindow(QWidget):
 
         if screen_index != self.screen_index:
             self.screen_index = screen_index
+            self.screens = QGuiApplication.screens()
             self.update_screen_geometry()
             # Update window position when screen changes
             self.move(self.window_bias_x, self.window_bias_y)


### PR DESCRIPTION
之前我的环境 holo-layer 只在单一screen和workspace上工作，修复了这个问题。

我的环境：

Arch
X11
Emacs 30.1
Spacemacs

---

主要fix：

1. 把判断frame focus的逻辑改成更普适一点的方法
1. `self.screens` 记录的 screens 偶尔会在Qt内部被释放掉，后续就会报错 `RuntimeError: wrapped C/C++ object of type QScreen has been deleted` 。gpt建议频繁调用 `QGuiApplication.screens()` ，它说这个函数开销几乎为0
1. `cl-position` 拿index 的 :test 在不同环境的表现不一样

---

我不特别确定的地方有两个

- [x] `cdar` 改成 `cdadr` ~~这个在别的环境是不是通用的，如果不同环境 `display-monitor-attributes-list` 不一样，这里是不是应该改成 defcustom holo-layer-monitor-idx-test-function 之类的，可以允许用户自行修改？~~ (Edit: 已解决，改用 alist-get)
- [ ] 我加了一个频繁 `setq holo-layer-emacs-frame` ，不知道这个修改以及位置好不好。我只知道我的环境如果这里不加好像不太行